### PR TITLE
support for nested module folder structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ elixir.extend('angular', function(src, output, outputFilename) {
         };
 
         // Module inits have to be included first.
-        return gulp.src([baseDir + "*_module.js", baseDir + "**/*.js"])
+        return gulp.src([baseDir + "*module.js", baseDir + "**/*module.js", baseDir + "**/*.js"])
             .pipe(jshint())
             .pipe(jshint.reporter(stylish))
             .pipe(jshint.reporter('fail')).on('error', onError)


### PR DESCRIPTION
Hi @HRcc!  So I really digg this gulp task, but had an issue using it on my folder structure.  This pull request satisfies my need, but also makes it a little more flexible in regards to where you can define your modules.  To start, I like to name my files like `foo.module.js` and `foo.controller.js`.  The hardcoded `_` in the task when looking for the main module makes my file names impossible to use in your plugin.  I've removed it in this pull request in favor of just `*module.js`.

The second issue I had was the inability to have a foldered structure inside the `/resources/angular` folder.  IE:

```
/resources
    /angular
        foo.module.js
        /some-feature
            some-feature.module.js
            some-feature.controller.js
```

The current functionality won't always put `some-feature.module.js` before the controller.  Adding a glob like `**/*module.js` before the final js glob will load those first so they will become available for anything else that's going to use that module.

Hopefully you find this useful!  This is a great plugin!  Thanks for your work!
